### PR TITLE
Replace deprecated CHARSET utf8 in install.sql

### DIFF
--- a/install.sql
+++ b/install.sql
@@ -14,35 +14,35 @@ CREATE TABLE IF NOT EXISTS `PREFIX_product_comment` (
   KEY `id_product` (`id_product`),
   KEY `id_customer` (`id_customer`),
   KEY `id_guest` (`id_guest`)
-) ENGINE=ENGINE_TYPE  DEFAULT CHARSET=utf8;
+) ENGINE=ENGINE_TYPE  DEFAULT CHARSET=utf8mb4;
 
 CREATE TABLE IF NOT EXISTS `PREFIX_product_comment_criterion` (
   `id_product_comment_criterion` int(10) unsigned NOT NULL auto_increment,
   `id_product_comment_criterion_type` tinyint(1) NOT NULL,
   `active` tinyint(1) NOT NULL,
   PRIMARY KEY (`id_product_comment_criterion`)
-) ENGINE=ENGINE_TYPE  DEFAULT CHARSET=utf8;
+) ENGINE=ENGINE_TYPE  DEFAULT CHARSET=utf8mb4;
 
 CREATE TABLE IF NOT EXISTS `PREFIX_product_comment_criterion_product` (
   `id_product` int(10) unsigned NOT NULL,
   `id_product_comment_criterion` int(10) unsigned NOT NULL,
   PRIMARY KEY(`id_product`, `id_product_comment_criterion`),
   KEY `id_product_comment_criterion` (`id_product_comment_criterion`)
-) ENGINE=ENGINE_TYPE DEFAULT CHARSET=utf8;
+) ENGINE=ENGINE_TYPE DEFAULT CHARSET=utf8mb4;
 
 CREATE TABLE IF NOT EXISTS `PREFIX_product_comment_criterion_lang` (
   `id_product_comment_criterion` INT(11) UNSIGNED NOT NULL ,
   `id_lang` INT(11) UNSIGNED NOT NULL ,
   `name` VARCHAR(64) NOT NULL ,
   PRIMARY KEY ( `id_product_comment_criterion` , `id_lang` )
-) ENGINE=ENGINE_TYPE  DEFAULT CHARSET=utf8;
+) ENGINE=ENGINE_TYPE  DEFAULT CHARSET=utf8mb4;
 
 CREATE TABLE IF NOT EXISTS `PREFIX_product_comment_criterion_category` (
   `id_product_comment_criterion` int(10) unsigned NOT NULL,
   `id_category` int(10) unsigned NOT NULL,
   PRIMARY KEY(`id_product_comment_criterion`, `id_category`),
   KEY `id_category` (`id_category`)
-) ENGINE=ENGINE_TYPE DEFAULT CHARSET=utf8;
+) ENGINE=ENGINE_TYPE DEFAULT CHARSET=utf8mb4;
 
 CREATE TABLE IF NOT EXISTS `PREFIX_product_comment_grade` (
   `id_product_comment` int(10) unsigned NOT NULL,
@@ -50,20 +50,20 @@ CREATE TABLE IF NOT EXISTS `PREFIX_product_comment_grade` (
   `grade` int(10) unsigned NOT NULL,
   PRIMARY KEY (`id_product_comment`, `id_product_comment_criterion`),
   KEY `id_product_comment_criterion` (`id_product_comment_criterion`)
-) ENGINE=ENGINE_TYPE DEFAULT CHARSET=utf8;
+) ENGINE=ENGINE_TYPE DEFAULT CHARSET=utf8mb4;
 
 CREATE TABLE IF NOT EXISTS `PREFIX_product_comment_usefulness` (
   `id_product_comment` int(10) unsigned NOT NULL,
   `id_customer` int(10) unsigned NOT NULL,
   `usefulness` tinyint(1) unsigned NOT NULL,
   PRIMARY KEY (`id_product_comment`, `id_customer`)
-) ENGINE=ENGINE_TYPE DEFAULT CHARSET=utf8;
+) ENGINE=ENGINE_TYPE DEFAULT CHARSET=utf8mb4;
 
 CREATE TABLE IF NOT EXISTS `PREFIX_product_comment_report` (
   `id_product_comment` int(10) unsigned NOT NULL,
   `id_customer` int(10) unsigned NOT NULL,
   PRIMARY KEY (`id_product_comment`, `id_customer`)
-) ENGINE=ENGINE_TYPE DEFAULT CHARSET=utf8;
+) ENGINE=ENGINE_TYPE DEFAULT CHARSET=utf8mb4;
 
 INSERT IGNORE INTO `PREFIX_product_comment_criterion` VALUES ('1', '1', '1');
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | mysql.com declared that utf8 was deprecated at https://dev.mysql.com/doc/refman/8.0/en/charset-unicode-utf8mb3.html. Installing with CHARSET = utf8 make tables with Unknown Collation
| Type?         | improvement
| BC breaks?    | no
| Deprecations? | yes
| Fixed ticket? | Fixes PrestaShop/Prestashop#{issue number here}.
| How to test?  | Just follow Prestashop Core / install / data / db_structure.sql rule

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
